### PR TITLE
fix: add typescript declaration for hlsQualitySelector method on videoJs.Player

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,7 @@
 import 'jest-extended';
+
+declare module 'video.js' {
+    export interface VideoJsPlayer {
+        hlsQualitySelector(options?: any): void;
+    }
+}


### PR DESCRIPTION
This pull request addresses the issue where the `hlsQualitySelector` method was not recognized on the `videoJs.Player `type, causing a TypeScript error.

The fix involves extending the `videoJs.Player` type to include the `hlsQualitySelector` method through module augmentation.