### PR TITLE
fix: http client error due to dependency injection issue in datafactory

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,7 +48,10 @@ function isTauri() {
 /**
  * Conditionally imports the necessary service based on the current environment
  */
-export function DataFactory(http: HttpClient) {
+export function DataFactory(
+    ngxIndexedDBService: NgxIndexedDBService,
+    http: HttpClient
+) {
     if (isElectron()) {
         return new ElectronService();
     }


### PR DESCRIPTION
This PR resolves a critical issue where NgxIndexedDBService was being injected into PwaService instead of HttpClient, causing runtime errors when making HTTP requests. The issue was traced to an incorrect dependency injection order in the DataFactory function.

![Screenshot 2024-11-28 at 15 14 06](https://github.com/user-attachments/assets/8b62401f-a1c8-4571-b110-7e2ed498f68a)
